### PR TITLE
Rename "on-site logistics" to "logistics"

### DIFF
--- a/ontology/crane_guidance/scenario.md
+++ b/ontology/crane_guidance/scenario.md
@@ -3,7 +3,7 @@
     "title": "Crane guidance",
     "contact": "Dag Fjeld Edvardsen <dag.fjeld.edvardsen@catenda.no>, Marko Ristin <rist@zhaw.ch>",
     "relations": [
-        { "target": "on-site_logistics", "nature": "specific" }
+        { "target": "logistics", "nature": "specific" }
     ],
     "volumetric": [
         {
@@ -59,22 +59,22 @@ This model lists all the <ref name="crane" />s available in the system.
 
 <def name="pickup_location">
 
-This is an `IfcZone` where the <ref name="on-site_logistics#delivery" /> needs to be picked up.
+This is an `IfcZone` where the <ref name="logistics#delivery" /> needs to be picked up.
 
 </def>
 
 <def name="attaching_slinger">
 
 The <ref name="actor_management#actor" /> who will attach 
-the <ref name="on-site_logistics#delivery" /> to the crane at the <ref name="pickup_location" />. 
+the <ref name="logistics#delivery" /> to the crane at the <ref name="pickup_location" />. 
 
 </def>
 
 <def name="detaching_slinger">
 
 The <ref name="actor_management#actor" /> who will take off 
-the <ref name="on-site_logistics#delivery" /> from the crane at 
-the <ref name="on-site_logistics#delivery_location" />. 
+the <ref name="logistics#delivery" /> from the crane at 
+the <ref name="logistics#delivery_location" />. 
 
 A detaching slinger can be identical with a <ref name="attaching_slinger" />.
 
@@ -82,13 +82,13 @@ A detaching slinger can be identical with a <ref name="attaching_slinger" />.
 
 <def name="crane_delivery">
 
-A crane delivery defines how the <ref name="on-site_logistics#delivery" /> should be transported
+A crane delivery defines how the <ref name="logistics#delivery" /> should be transported
 within the construction site by a <ref name="crane" />.
 
 Each crane delivery is associated with:
 * a <ref name="pickup_location" /> and 
   the corresponding one or more <ref name="attaching_slinger" />s,
-* the <ref name="on-site_logistics#delivery_location" /> and 
+* the <ref name="logistics#delivery_location" /> and 
   the corresponding one or more <ref name="detaching_slinger" />s, and
 * the <ref name="crane" />,
 * the <ref name="crane_supervisor" />, and 
@@ -98,7 +98,7 @@ Each crane delivery is associated with:
 
 <def name="crane_operator">
 
-The crane operator is an <ref name="on-site_logistics#operator" /> who controls the <ref name="crane" />.
+The crane operator is an <ref name="logistics#operator" /> who controls the <ref name="crane" />.
 
 </def>
 
@@ -106,7 +106,7 @@ The crane operator is an <ref name="on-site_logistics#operator" /> who controls 
 
 Crane supervisor is an <ref name="actor_management#actor" /> 
 who helps the <ref name="crane_operator" /> by guiding her during 
-the <ref name="on-site_logistics#delivery" />.
+the <ref name="logistics#delivery" />.
 
 She has the final authority.
 
@@ -140,8 +140,8 @@ The crane state captures the state of the crane, including:
 
 ### As-planned
 
-<level name="site">The <ref name="on-site_logistics#planner_role" /> specifies the 
-<ref name="on-site_logistics#delivery" />s (with additional information
+<level name="site">The <ref name="logistics#planner_role" /> specifies the 
+<ref name="logistics#delivery" />s (with additional information
 defined) as <ref name="crane_delivery" />s.</level>
 
 ### As-observed
@@ -154,7 +154,7 @@ as <ref name="crane_state" /> in <modelref name="crane_log" />.</level>
 <level name="machine">
 
 The  device will guide the <ref name="crane_operator" /> and the 
-<ref name="crane_supervisor" /> to the <ref name="on-site_logistics#delivery_location" />.
+<ref name="crane_supervisor" /> to the <ref name="logistics#delivery_location" />.
 
 Since the <ref name="crane_delivery" /> is very dynamic, we explicitly do not provide a mechanism
 to signal the <ref name="attaching_slinger" />s and <ref name="detaching_slinger" />s when the
@@ -166,7 +166,7 @@ to signal the <ref name="attaching_slinger" />s and <ref name="detaching_slinger
 
 <level name="site">
 
-For a given time range, the <ref name="on-site_logistics#planner_role" /> should be able to inspect
+For a given time range, the <ref name="logistics#planner_role" /> should be able to inspect
 the plan of the <ref name="crane_delivery" />s as association between the <ref name="crane" />s,
 <ref name="crane_operator" />s, <ref name="crane_supervisor" />s and 
 <ref name="scheduling#task" />s (if available). 
@@ -199,8 +199,8 @@ can measure it).
 
 ## Test Cases
 
-Please see the test cases of <scenarioref name="on-site_logistics" />.
+Please see the test cases of <scenarioref name="logistics" />.
 
 ## Acceptance Criteria
 
-Please see the acceptance criteria of <scenarioref name="on-site_logistics" />.
+Please see the acceptance criteria of <scenarioref name="logistics" />.

--- a/ontology/evolving_plan/scenario.md
+++ b/ontology/evolving_plan/scenario.md
@@ -149,7 +149,7 @@ As these revisions are costly and official, they are not frequently done.
 
 The <ref name="extension_update" /> of the internal <modelref name="bim_extended" /> 
 occurs much more frequently than the official <ref name="revision" />s. 
-For example, when a new <ref name="on-site_logistics#delivery" /> is inserted into the system.
+For example, when a new <ref name="logistics#delivery" /> is inserted into the system.
 
 **Inconsistencies.** 
 On every <ref name="revision" />, there might be inconsistency introduced between 
@@ -176,7 +176,7 @@ For example, you should not give the same <ref name="guid" /> to a wall and to a
 
 **Non-IFC entities**.
 Our system supports many non-IFC entities (such as <ref name="risk_management#risk" /> and
-<ref name="on-site_logistics#delivery_update" />).
+<ref name="logistics#delivery_update" />).
 
 In order to make these entities referencable by IFC entities, every <ref name="non_ifc_entity" />
 needs to be shadowed in <modelref name="bim_extended" /> as an `IfcExternalReference`.

--- a/ontology/logistics/scenario.md
+++ b/ontology/logistics/scenario.md
@@ -1,6 +1,6 @@
 <rasaeco-meta>
 {
-    "title": "On-site Logistics",
+    "title": "Logistics",
     "contact": "Dag Fjeld Edvardsen <dag.fjeld.edvardsen@catenda.no>, Marko Ristin <rist@zhaw.ch>",
     "relations": [
         { "target": "topic_management", "nature": "deliveries" }

--- a/ontology/scheduling/scenario.md
+++ b/ontology/scheduling/scenario.md
@@ -198,8 +198,8 @@ to the <ref name="last_planner_system" />.
 
 There are also more structured options available in the system.
 For example, a delivery task can be automatically converted to
-<ref name="on-site_logistics#delivery" /> as a <ref name="topic_management#topic" />
-(see <scenarioref name="on-site_logistics" />).
+<ref name="logistics#delivery" /> as a <ref name="topic_management#topic" />
+(see <scenarioref name="logistics" />).
 
 **Closing of <ref name="task" />s**.
 Since we do not control the <ref name="last_planner_task" />s (we only import them),
@@ -211,7 +211,7 @@ The user or the system should be able to convert a <ref name="last_planner_task"
 
 In many cases, if the system is tracking the status and not the user, we use structured
 <ref name="topic_management#comment" />s.
-For example, the task corresponding to a <ref name="on-site_logistics#delivery" /> is converted to a
+For example, the task corresponding to a <ref name="logistics#delivery" /> is converted to a
 <ref name="topic_management#topic" />.
 So when the delivery is terminated, we can close the <ref name="topic_management#topic" />
 (which we control), but we can only notify the <ref name="scheduler" />.
@@ -222,8 +222,8 @@ We emphasize here that there is only a
 [unidirectional data flow](https://en.wikipedia.org/wiki/Unidirectional_Data_Flow_(computer_science)):
 1) <ref name="last_planner_task" /> to
 2) <ref name="task_shadow" /> (*via* synchronization) to
-3) <ref name="on-site_logistics#delivery" /> (*via* conversion) to
-4) delivery closed (*via* <ref name="on-site_logistics#delivery_update" />) to
+3) <ref name="logistics#delivery" /> (*via* conversion) to
+4) delivery closed (*via* <ref name="logistics#delivery_update" />) to
 5) <ref name="last_planner_task" /> closed (manually *via* <ref name="last_planner_system" />) to
 6) <ref name="task_shadow" /> closed (*via* synchronization).
 

--- a/ontology/topic_management/scenario.md
+++ b/ontology/topic_management/scenario.md
@@ -60,7 +60,7 @@ A topic board (called "project" in <ref name="BCF" />) is a collection of <ref n
 
 A topic board can have different access rights as well as different semantics.
 
-For example, there is a special topic board for <ref name="on-site_logistics#delivery" />s.
+For example, there is a special topic board for <ref name="logistics#delivery" />s.
 
 </def>
 
@@ -104,7 +104,7 @@ Comments are usually free-form.
 
 There are also specially structured comments.
 For example, we use comments to represent the status change of a 
-<ref name="on-site_logistics#delivery" />.
+<ref name="logistics#delivery" />.
 
 </def>
 
@@ -205,7 +205,7 @@ The user can create a <ref name="topic" /> from an arbitrary <ref name="scheduli
 using <scenarioref name="scheduling" />.
 
 There is also a more structured task-to-topic translation for specific tasks such as
-<ref name="on-site_logistics#delivery" />s.
+<ref name="logistics#delivery" />s.
 
 **Export to <ref name="BCF" />**.
 The <ref name="topic" />s are exportable to <ref name="BCF" />.

--- a/ontology/truck_guidance/scenario.md
+++ b/ontology/truck_guidance/scenario.md
@@ -3,7 +3,7 @@
     "title": "Truck guidance",
     "contact": "Dag Fjeld Edvardsen <dag.fjeld.edvardsen@catenda.no>, Marko Ristin <rist@zhaw.ch>",
     "relations": [
-        { "target": "on-site_logistics", "nature": "specific" }
+        { "target": "logistics", "nature": "specific" }
     ],
     "volumetric": [
         {
@@ -24,7 +24,7 @@
 
 This scenario concerns truck drivers arriving at the construction site to deliver cargo.
 
-This is a specification of the <scenarioref name="on-site_logistics" /> where the cargo is
+This is a specification of the <scenarioref name="logistics" /> where the cargo is
 delivered by trucks.
 
 ## Models
@@ -53,7 +53,7 @@ The `IfcZone` where the truck should leave through.
 
 <def name="truck_delivery">
 
-A truck delivery defines how the <ref name="on-site_logistics#delivery" /> should be brought on
+A truck delivery defines how the <ref name="logistics#delivery" /> should be brought on
 the construction site by the truck.
 
 Each truck delivery is associated with the <ref name="entry_point" /> and <ref name="exit_point" />
@@ -63,7 +63,7 @@ so that other entrances and exits do not get congested.
 
 <def name="driver">
 
-The driver is a more specific <ref name="on-site_logistics#operator" /> for 
+The driver is a more specific <ref name="logistics#operator" /> for 
 <ref name="truck_delivery" />s.
 
 </def>
@@ -72,7 +72,7 @@ The driver is a more specific <ref name="on-site_logistics#operator" /> for
 
 ### As-planned
 
-<level name="site">The <ref name="on-site_logistics#delivery" />s are specified with additional information
+<level name="site">The <ref name="logistics#delivery" />s are specified with additional information
 defined as <ref name="truck_delivery" />s.</level>
 
 ### As-observed
@@ -89,27 +89,27 @@ The location is only used to navigate the driver.
 ### Divergence
 
 <level name="machine">The  device will guide the <ref name="driver" /> to the
-<ref name="on-site_logistics#delivery_location" />.</level>
+<ref name="logistics#delivery_location" />.</level>
 
 <level name="machine">
 
 The <ref name="topic_management#topic" /> body includes a link
 (authorized for the whole internet) that the <ref name="driver" /> can click on to update
 the current location of the delivery and another link to signal that
-the <ref name="on-site_logistics#delivery" /> arrived.
+the <ref name="logistics#delivery" /> arrived.
 
 The <ref name="driver" /> can choose to include his/her current GPS location
-in the <ref name="on-site_logistics#delivery_update" /> (*e.g.*, when following the link for the arrival).
+in the <ref name="logistics#delivery_update" /> (*e.g.*, when following the link for the arrival).
 
 The updates of the delivery status are kept track in the
-<modelref name="on-site_logistics#logs" />.
+<modelref name="logistics#logs" />.
 
 </level>
 
 ## Test Cases
 
-Please see the test cases of <scenarioref name="on-site_logistics" />.
+Please see the test cases of <scenarioref name="logistics" />.
 
 ## Acceptance Criteria
 
-Please see the acceptance criteria of <scenarioref name="on-site_logistics" />.
+Please see the acceptance criteria of <scenarioref name="logistics" />.

--- a/ontology/unique_resource_identification/scenario.md
+++ b/ontology/unique_resource_identification/scenario.md
@@ -37,7 +37,7 @@ concepts, or information resources such web pages and books.
 ## Scenario
 
 Our system supports many non-IFC entities (such as <ref name="risk_management#risk" /> and
-<ref name="on-site_logistics#delivery_update" />).
+<ref name="logistics#delivery_update" />).
 
 Since we shadow these entities as references in BIM through 
 <ref name="evolving_plan#non_ifc_entity" />, they need an <ref name="identifier" />.


### PR DESCRIPTION
The term "on-site logistics" was misleading as the scenario "Truck
Delivery" implied *on-site* truck deliveries, while we had external
(3rd-party) deliveries in mind.